### PR TITLE
[baseframe.py]: fix chinese info output

### DIFF
--- a/baseframe.py
+++ b/baseframe.py
@@ -9,7 +9,8 @@ import os
 import sys
 import traceback
 
-from pprint import pprint
+import json
+
 from optparse import OptionParser, OptionGroup
 
 from utils import http
@@ -91,7 +92,7 @@ class BaseFrame(object):
         pass
 
     def __cb_print_poc_info(self, option, opt, value, parser):
-        pprint(self.poc_info, stream=None, indent=2, width=80, depth=None)
+        print(json.dumps(self.poc_info, ensure_ascii=False, indent=2))
         sys.exit()
 
     @classmethod


### PR DESCRIPTION
使用 pprint 输出的时候中文会输出类似 \xe9\xaa\x8c\xe8\xaf 的编码，用 json 可以正常输出中文。
如下图：
![133](https://cloud.githubusercontent.com/assets/2796153/8900135/60190894-346f-11e5-9fd1-f336dab7cdc1.png)
![133](https://cloud.githubusercontent.com/assets/2796153/8900153/87cdb560-346f-11e5-831d-bb0d1f5efe8e.png)
图中的 \n 是因为 poc 里用了三引号。
